### PR TITLE
Start on a Thing database using SQLite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+db.sqlite3

--- a/app.js
+++ b/app.js
@@ -1,17 +1,27 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/*
+ * MozIoT Gateway App.
+ *
+ * Back end main script.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 var express = require('express');
+var db = require('./db');
 var app = express();
 
-app.use('/things', function(request, response) {
-  var options = {
-    root: 'static'
-  };
-  response.sendFile('things.json', options);
-});
+// Open the thing database.
+db.open();
+
+// Serve Things from Things router
+var thingsRouter = require('./routes/things_router');
+app.use('/things', thingsRouter);
+
+// Serve static files from static/ directory
 app.use(express.static('static'));
 
+// Start HTTP server on port 8080
 app.listen(8080, function () {
   console.log('Listening on port 8080.');
 });

--- a/db.js
+++ b/db.js
@@ -1,0 +1,87 @@
+/**
+ * MozIoT Gateway Database.
+ *
+ * Stores a list of Things connected to the gateway.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+var sqlite3 = require('sqlite3').verbose();
+var fs = require('fs');
+
+var Database = {
+  /**
+   * Filename to use for SQLLite 3 database.
+   */
+  DB_FILENAME: 'db.sqlite3',
+
+  /**
+   * Filename to use for default list of Things.
+   */
+  DATA_FILENAME: 'static/things.json',
+
+  /**
+   * SQLLite3 Database object.
+   */
+  db: null,
+
+  /**
+   * Open the database.
+   */
+  open: function() {
+    var filename = './' + this.DB_FILENAME;
+    // Check if database already exists
+    var exists = fs.existsSync(filename);
+    // Open database or create it if it doesn't exist
+    this.db = new sqlite3.Database(this.DB_FILENAME);
+    // If database newly created, populate with default data
+    if (!exists) {
+      this.populate();
+    }
+  },
+
+  /**
+   * Populate the database with default data.
+   */
+  populate: function() {
+    console.log('Populating database with default things...');
+    var things = require('./' + this.DATA_FILENAME);
+    var db = this.db;
+    var createTableSQL = 'CREATE TABLE IF NOT EXISTS things (' +
+      'id INTEGER PRIMARY KEY ASC,' +
+      'description TEXT' +
+    ');';
+    db.serialize(function() {
+      db.run(createTableSQL);
+      var insertSQL = db.prepare('INSERT INTO things (description) VALUES (?)');
+      for (var thing of things) {
+        insertSQL.run(JSON.stringify(thing));
+      }
+      insertSQL.finalize();
+    });
+  },
+
+  /**
+   * Get all Things stored in the database.
+   *
+   * @return Promise which resolves with a list of Thing objects.
+   */
+  getAllThings: function() {
+    return new Promise((function(resolve, reject) {
+      this.db.all('SELECT rowid AS id, description FROM things', (function(err, rows) {
+        if (err) {
+          reject(err);
+        } else {
+          var things = [];
+          for (row of rows) {
+            things.push(JSON.parse(row.description));
+          }
+          resolve(things);
+        }
+      }));
+    }).bind(this));
+  }
+}
+
+module.exports = Database;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://wiki.mozilla.org/MozIoT",
   "dependencies": {
     "body-parser": "^1.17.1",
-    "express": "^4.15.2"
+    "express": "^4.15.2",
+    "sqlite3": "^3.1.8"
   }
 }

--- a/routes/things_router.js
+++ b/routes/things_router.js
@@ -1,0 +1,20 @@
+/**
+ * Things Router.
+ *
+ * Manages HTTP requests to /things.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+var express = require('express');
+var ThingsRouter = express.Router();
+var Database = require('../db.js');
+
+ThingsRouter.get('/', function (request, response) {
+  Database.getAllThings().then(function(things) {
+    response.send(JSON.stringify(things));
+  });
+});
+
+module.exports = ThingsRouter;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,8 @@
 /**
  * MozIoT Gateway App.
  *
+ * Front end main script.
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/static/things.json
+++ b/static/things.json
@@ -3,6 +3,7 @@
     "name": "Smart Switch (ZigBee)",
     "description": "On/Off Switch",
     "type": "onOffSwitch",
+    "href": "/things/onOffSwitch1",
     "properties":[
       {
         "name": "on",
@@ -21,6 +22,7 @@
     "name": "Smart Switch (Z-Wave)",
     "description": "On/Off Switch",
     "type": "onOffSwitch",
+    "href": "/things/onOffSwitch2",
     "properties":[
       {
         "name": "on",


### PR DESCRIPTION
Load /things from an SQLite database rather than a static JSON file on disk, and populate it with some default things on first run. Next step will be adding/removing things to database, then adding things from adapters. Includes creating a /things Express router which handles HTTP requests to /things by calling the database.