### PR TITLE
Add discover

### DIFF
--- a/adapter-manager.js
+++ b/adapter-manager.js
@@ -1,8 +1,9 @@
 /**
- * AdapterManager.
+ * Manages all of the Adapters used in the system.
  *
- * Manages Adapter data model and business logic.
- *
+ * @module AdapterManager
+ */
+/**
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
@@ -14,6 +15,11 @@ var fs = require('fs');
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
 
+/**
+ * @class AdapterManager
+ * @classdesc The AdapterManager will load any adapters from the 'adapters'
+ * directory. See loadAdapters() for details.
+ */
 class AdapterManager extends EventEmitter {
 
   constructor() {
@@ -22,29 +28,117 @@ class AdapterManager extends EventEmitter {
     this.devices = {};
   }
 
+  /**
+   * Adds an adapter to the collection of adapters managed by AdapterManager.
+   * This function is typically called when loading adapters.
+   */
   addAdapter(adapter) {
     adapter.name = adapter.constructor.name;
     this.adapters.push(adapter);
+
+    /**
+     * Adapter added event.
+     *
+     * This is event is emitted whenever a new adapter is loaded.
+     *
+     * @event adapter-added
+     * @type  {Adapter}
+     */
     this.emit('adapter-added', adapter);
   }
 
-  addDevice(adapter, device) {
+  addDevice(device) {
     this.devices[device.id] = device;
+
+    /**
+     * Device added event.
+     *
+     * This event is emitted whenever a new device is added.
+     *
+     * @event device-added
+     * @type  {Device}
+     */
     this.emit('device-added', device);
   }
 
+  removeDevice(device) {
+    delete this.devices[device.id];
+
+    /**
+     * Device removed event.
+     *
+     * This event is emitted whenever a new device is removed.
+     *
+     * @event device-added
+     * @type  {Device}
+     */
+    this.emit('device-removed', device);
+  }
+
+  /**
+   * @method discoverAdapters
+   * @returns A promise that resolves to an array of known adapters.
+   */
+  discoverAdapters() {
+    var adapterManager = this;
+    return new Promise(function(resolve, reject) {
+      resolve(adapterManager.adapters);
+    });
+  }
+
+  /**
+   * @method discoverDevices
+   * @returns A promise that resolves to dictionary of all known devices.
+   */
+  discoverDevices() {
+    var adapterManager = this;
+    return new Promise(function(resolve, reject) {
+      resolve(adapterManager.devices);
+    });
+  }
+
+  /**
+   * @method getAdapter
+   * @returns te adapter with the indicated 'id'.
+   */
+  getAdapter(id) {
+    for (var adapter of this.adapters) {
+      if (adapter.getId() == id) {
+        return adapter;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * @method getAdapters
+   * @returns an array of known adapters.
+   */
   getAdapters() {
     return this.adapters;
   }
 
+  /**
+   * @method getDevice
+   * @returns the device with the indicated 'id'.
+   */
   getDevice(id) {
     return this.devices[id];
   }
 
+  /**
+   * @method getDevices
+   * @returns an array of known devices.
+   */
   getDevices() {
     return this.devices;
   }
 
+  /**
+   * Loads all of the adapters from the adapters directory.
+   * @method loadAdapters
+   *
+   */
   loadAdapters() {
     var adapterDir = './adapters';
     var adapterManager = this;
@@ -61,8 +155,8 @@ class AdapterManager extends EventEmitter {
         }
         console.log('Loading Adapters from', adapterFilename);
 
-        let loadAdapters = require(adapterFilename);
-        loadAdapters(adapterManager);
+        let adapterLoader = require(adapterFilename);
+        adapterLoader(adapterManager);
       }
     });
   }

--- a/adapter.js
+++ b/adapter.js
@@ -1,8 +1,9 @@
 /**
- * Adapter Model.
+ * @module Adapter base class.
  *
  * Manages Adapter data model and business logic.
- *
+ */
+/**
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
@@ -10,17 +11,69 @@
 
 'use strict';
 
+/**
+ * Base class for adapters, which manage devices.
+ * @class Adapter
+ *
+ */
 class Adapter {
 
   constructor(adapterManager, id) {
     this.manager = adapterManager;
     this.id = id;
     this.name = this.constructor.name;
+    this.devices = {};
+
+    // We assume that the adapter is ready right away. If, for some reason
+    // a particular adapter (like ZWave) needs some time, then it should
+    // set ready to false in its constructor.
+    this.ready = true;
     console.log('Adapter:', this.name, 'id', id, 'created');
   }
 
+  /**
+   * @method getId
+   * @returns the id of this adapter.
+   */
   getId() {
     return this.id;
+  }
+
+  getDevice(id) {
+    return this.devices[id];
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  isReady() {
+    return this.ready;
+  }
+
+  asDict() {
+    return {
+      'id': this.id,
+      'name': this.name,
+      'ready': this.ready,
+    }
+  }
+
+  addDevice(device) {
+    this.devices[device.id] = device;
+    this.manager.addDevice(device);
+  }
+
+  removeDevice(device) {
+    delete this.devices[device.id];
+    this.manager.removeDevice(device);
+  }
+
+  discoverDevices() {
+    var adapter = this;
+    return new Promise(function(resolve, reject) {
+      resolve(adapter.devices);
+    });
   }
 
   pair() {

--- a/adapters/foo.js
+++ b/adapters/foo.js
@@ -49,10 +49,10 @@ class FooDevice extends Device {
 class FooAdapter extends Adapter {
 
   constructor(adapterManager) {
-    super(adapterManager);
+    super(adapterManager, 'Foo1');
 
-    adapterManager.addDevice(this, new FooDevice(this, 'Foo1', 'device1'));
-    adapterManager.addDevice(this, new FooDevice(this, 'Foo2', 'device2'));
+    this.addDevice(new FooDevice(this, 'Foo1', 'device1'));
+    this.addDevice(new FooDevice(this, 'Foo2', 'device2'));
   }
 }
 

--- a/adapters/zwave/zwave-adapter.js
+++ b/adapters/zwave/zwave-adapter.js
@@ -18,7 +18,9 @@ const DEBUG = false;
 
 class ZWaveAdapter extends Adapter {
   constructor(adapterManager, port) {
-    super(adapterManager);
+    // We
+    super(adapterManager, '???');
+    this.ready = false;
 
     this.port = port;
     this.nodes = {};
@@ -57,8 +59,7 @@ class ZWaveAdapter extends Adapter {
 
   driverReady(homeId) {
     console.log('ZWave: Driver Ready: HomeId:', homeId.toString(16));
-    this.id = homeId;
-    this.manager.addAdapter(this);
+    this.id = 'zwave-' + homeId.toString(16);
   }
 
   driverFailed() {
@@ -68,6 +69,7 @@ class ZWaveAdapter extends Adapter {
 
   scanComplete() {
     console.log('ZWave: Scan complete');
+    this.ready = true;
     this.zwave.requestAllConfigParams(3);
     if (DEBUG) {
       this.dump();
@@ -154,9 +156,9 @@ class ZWaveAdapter extends Adapter {
           'type': 'bool',
           'value': false,
         };
-        this.manager.addDevice(this, node);
+        this.addDevice(node);
       } else {
-        this.manager.addDevice(this, node);
+        this.addDevice(node);
       }
     }
   }
@@ -284,6 +286,7 @@ function loadZWaveAdapters(adapterManager) {
     }
 
     console.log('Found ZWave port @', port.comName);
+
     adapterManager.addAdapter(new ZWaveAdapter(adapterManager, port));
   });
 }

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@
 var express = require('express');
 var db = require('./db');
 var app = express();
+var adapterManager = require('./adapter-manager.js');
 
 // Open the thing database.
 db.open();
@@ -18,10 +19,30 @@ db.open();
 var thingsRouter = require('./controllers/things_controller');
 app.use('/things', thingsRouter);
 
+// Serve Adapters from Adapters router.
+var adaptersRouter = require('./controllers/adapters_controller');
+app.use('/adapters', adaptersRouter);
+
 // Serve static files from static/ directory
 app.use(express.static('static'));
+
+// Get some decent error messages for unhandled rejections. This is
+// often just errors in the code.
+process.on('unhandledRejection', (reason) => {
+  console.error(reason);
+  process.exit(1);
+});
+
+// Do graceful shutdown when Control-C is pressed.
+process.on('SIGINT', function() {
+  console.log('Control-C: disconnecting adapters...');
+  adapterManager.unloadAdapters();
+  process.exit();
+});
 
 // Start HTTP server on port 8080
 app.listen(8080, function () {
   console.log('Listening on port 8080.');
+
+  adapterManager.loadAdapters();
 });

--- a/controllers/adapters_controller.js
+++ b/controllers/adapters_controller.js
@@ -1,0 +1,68 @@
+/**
+ * Adapter Controller.
+ *
+ * Manages HTTP requests to /adapters. 
+ *  
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+var express = require('express');
+var adapterManager = require('../adapter-manager');
+
+var AdaptersController = express.Router();
+
+AdaptersController.get('/', function (request, response) {
+  adapterManager.discoverAdapters().then(function(adapters) {
+    var adapterList = [];
+    for (var adapter of adapters) {
+      adapterList.push(adapter.asDict());
+    }
+    response.json(adapterList);
+  });
+});
+
+AdaptersController.get('/:adapterId/', function (request, response) {
+  var adapterId = request.params['adapterId'];
+  var adapter = adapterManager.getAdapter(adapterId);
+  if (adapter) {
+    response.json(adapter.asDict());
+    return;
+  }
+  response.status(404).send('Adapter "' + adapterId + '" not found.');
+});
+
+AdaptersController.get('/:adapterId/devices/', function (request, response) {
+  var adapterId = request.params['adapterId'];
+  var adapter = adapterManager.getAdapter(adapterId);
+  if (adapter) {
+    adapter.discoverDevices().then(function(devices) {
+      var deviceList = [];
+      for (var deviceId in adapter.devices) {
+        var device = adapter.devices[deviceId];
+        deviceList.push(device.asDict());
+      }
+      response.json(deviceList);
+    });
+    return;
+  }
+  response.status(404).send('Adapter "' + adapterId + '" not found.');
+});
+
+AdaptersController.get('/:adapterId/devices/:deviceId/', function (request, response) {
+  var adapterId = request.params['adapterId'];
+  var deviceId = request.params['deviceId'];
+  var adapter = adapterManager.getAdapter(adapterId);
+  if (adapter) {
+    var device = adapter.getDevice(deviceId);
+    if (device) {
+      response.json(device.asDict());
+      return;
+    }
+    response.status(404).send('Adapter "' + adapterId + '" device "' + deviceId + '" not found.');
+    return;
+  }
+  response.status(404).send('Adapter "' + adapterId + '" not found.');
+});
+
+module.exports = AdaptersController;

--- a/device.js
+++ b/device.js
@@ -20,6 +20,15 @@ class Device {
         this.attributes = attributes;
     }
 
+    asDict() {
+        return {
+            'id': this.id,
+            'name': this.name,
+            'type': this.type,
+            'attributes': this.attributes,
+        };
+    }
+
     getId() {
       return this.id;
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
     "openzwave-shared": "^1.3.2",
+    "promise": "^7.1.1",
     "serialport": "^4.0.7",
     "sqlite3": "^3.1.8"
   }


### PR DESCRIPTION
This adds discoverAdapters and discoverDevices.

I started to look at hooking them in, but I wasn't sure exactly where you wanted them.

I also experimented a bit with jsDoc and added a bit of jsDoc documentation. If this looks reasonable, I'll continue to add documentation this way.

You can install jsdoc by doing `npm install jsdoc` and then just run `./node_modules/.bin/jsdoc .` and open `out/index.html` to see the generated documentation.