### PR TITLE
Added adapter for GPIO output

### DIFF
--- a/adapters/gpio/gpio-adapter.js
+++ b/adapters/gpio/gpio-adapter.js
@@ -1,0 +1,118 @@
+/**
+ *
+ * GpioAdapter - an adapter for controlling GPIO pins.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+'use strict';
+
+var fs = require('fs');
+var Gpio = require('onoff').Gpio;
+var Device = require('../../device.js').Device;
+var Adapter = require('../../adapter.js').Adapter;
+
+const THING_TYPE_ON_OFF_SWITCH = 'onOffSwitch';
+
+class GpioDevice extends Device {
+  constructor(adapter, pin, pinConfig) {
+    var id = 'gpio-' + pin;
+    super(adapter, id);
+
+    if (pinConfig.direction === undefined) {
+      pinConfig.direction = 'in';
+    }
+    if (pinConfig.name === undefined) {
+      pinConfig.name = id;
+    }
+    if (pinConfig.direction == 'in') {
+      if (pinConfig.edge === undefined) {
+        pinConfig.edge = 'none';
+      }
+      this.gpio = new Gpio(pin, 'in', pinConfig.edge);
+    } else if (pinConfig.direction == 'out') {
+      if (pinConfig.value === undefined) {
+        pinConfig.value = 0;
+      }
+      this.gpio = new Gpio(pin, 'out');
+      this.gpio.writeSync(pinConfig.value);
+    }
+    pinConfig.pin = pin;
+    this.pinConfig = pinConfig;
+    this.name = pinConfig.name;
+
+    if (pinConfig.direction === 'out') {
+      this.initOnOffSwitch();
+      this.adapter.handleDeviceAdded(this);
+    }
+  }
+
+  asDict() {
+    var dict = super.asDict();
+    dict.pinConfig = this.pinConfig;
+    return dict;
+  }
+
+  initOnOffSwitch() {
+    this.type = THING_TYPE_ON_OFF_SWITCH;
+    this.properties = [{
+      'name': 'on',
+      'type': 'boolean',
+    }];
+    this.values['on'] = (this.pinConfig.value != 0);
+  }
+
+  getProperty(propertyName) {
+    if (propertyName in this.values) {
+      return this.values[propertyName];
+    }
+  }
+
+  setProperty(propertyName, value) {
+    this.values[propertyName] = value;
+    console.log('GPIO:', this.name, 'set:', propertyName, 'to:', value);
+    this.gpio.writeSync(value ? 1 : 0);
+    this.notifyValueChanged(propertyName, value);
+  }
+}
+
+class GpioAdapter extends Adapter {
+
+  constructor(adapterManager, gpioConfigs) {
+    super(adapterManager, 'GPIO');
+
+    for (var pin in gpioConfigs) {
+      /* jshint -W031 */
+      new GpioDevice(this, pin, gpioConfigs[pin]);
+    }
+  }
+}
+
+function loadGpioAdapters(adapterManager) {
+  var gpioConfigFilename = 'config/gpio-config.js';
+
+  // Verify that we have write permissions to /sys/class/gpio/export. Under
+  // regular linux, this file is owned by root, so the server would need to
+  // run as the root user. On the Raspberry Pi, being a member of the gpio
+  // group allows non-root access.
+  //
+  // This file won't exist on Mac/Windows.
+  try {
+    fs.accessSync('/sys/class/gpio/export', fs.constants.W_OK);
+  } catch (err) {
+    console.log('Not starting GPIO adapter - no permissions to /sys/class/gpio/export')
+    return;
+  }
+
+  if (fs.existsSync(gpioConfigFilename)) {
+    var gpioConfigs = require('../../' + gpioConfigFilename);
+    /* jshint -W031 */
+    new GpioAdapter(adapterManager, gpioConfigs);
+  } else {
+    console.log('Not starting GPIO adapter - no config file');
+  }
+}
+
+module.exports = loadGpioAdapters;

--- a/adapters/gpio/index.js
+++ b/adapters/gpio/index.js
@@ -1,0 +1,15 @@
+/**
+ *
+ * index.js - Loads the ZigBee adapter.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+
+'use strict';
+
+var loadGpioAdapters = require('./gpio-adapter.js');
+
+module.exports = loadGpioAdapters;

--- a/config/gpio-config-example.js
+++ b/config/gpio-config-example.js
@@ -1,0 +1,7 @@
+module.exports = {
+  18: {
+    name: 'led',
+    direction: 'out',
+    value: 0
+  },
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.15.2",
     "express-ws": "^3.0.0",
     "node-getopt": "^0.2.3",
+    "onoff": "^1.1.2",
     "openzwave-shared": "^1.3.2",
     "serialport": "^4.0.7",
     "sqlite3": "^3.1.8",


### PR DESCRIPTION
This adds an adapter for output GPIOs. To use, copuy the config/gpio-config-example.js to config/gpio-config.js and edit appropriately.

Example of it running can be found here:
https://www.youtube.com/watch?v=sODPG_wM4jY