### PR TITLE
Fix GPIO failing to load on OSX

### DIFF
--- a/adapters/gpio/gpio-adapter.js
+++ b/adapters/gpio/gpio-adapter.js
@@ -91,29 +91,9 @@ class GpioAdapter extends Adapter {
   }
 }
 
-function loadGpioAdapters(adapterManager) {
-  var gpioConfigFilename = 'config/gpio-config.js';
-
-  // Verify that we have write permissions to /sys/class/gpio/export. Under
-  // regular linux, this file is owned by root, so the server would need to
-  // run as the root user. On the Raspberry Pi, being a member of the gpio
-  // group allows non-root access.
-  //
-  // This file won't exist on Mac/Windows.
-  try {
-    fs.accessSync('/sys/class/gpio/export', fs.constants.W_OK);
-  } catch (err) {
-    console.log('Not starting GPIO adapter - no permissions to /sys/class/gpio/export')
-    return;
-  }
-
-  if (fs.existsSync(gpioConfigFilename)) {
-    var gpioConfigs = require('../../' + gpioConfigFilename);
-    /* jshint -W031 */
-    new GpioAdapter(adapterManager, gpioConfigs);
-  } else {
-    console.log('Not starting GPIO adapter - no config file');
-  }
+function loadGpioAdapter(adapterManager, gpioConfig) {
+  /* jshint -W031 */
+  new GpioAdapter(adapterManager, gpioConfigs);
 }
 
-module.exports = loadGpioAdapters;
+module.exports = loadGpioAdapter;

--- a/adapters/gpio/index.js
+++ b/adapters/gpio/index.js
@@ -7,9 +7,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-
 'use strict';
 
-var loadGpioAdapters = require('./gpio-adapter.js');
+function maybeLoadGpioAdapter(adapterManager) {
+  var gpioConfigFilename = 'config/gpio-config.js';
 
-module.exports = loadGpioAdapters;
+  // Verify that we have write permissions to /sys/class/gpio/export. Under
+  // regular linux, this file is owned by root, so the server would need to
+  // run as the root user. On the Raspberry Pi, being a member of the gpio
+  // group allows non-root access.
+  //
+  // This file won't exist on Mac/Windows.
+  try {
+    fs.accessSync('/sys/class/gpio/export', fs.constants.W_OK);
+  } catch (err) {
+    console.log('Not starting GPIO adapter - no permissions to /sys/class/gpio/export');
+    return;
+  }
+
+  if (!fs.existsSync(gpioConfigFilename)) {
+    console.log('Not starting GPIO adapter - no config file');
+    return;
+  }
+
+  var gpioConfigs = require('../../' + gpioConfigFilename);
+
+  var loadGpioAdapter = require('./gpio-adapter.js');
+  loadGpioAdapter(adapterManager, gpioConfigs);
+}
+
+module.exports = maybeLoadGpioAdapter;


### PR DESCRIPTION
It turns out that I negelected to test the finished gpio adapter under OSX, and even trying to load the onoff module causes problems.

So this moves the test for loading the module into from gpio/gpio-adapter.js into gpio/index.js.
Now it only trys to load onoff if the first few tests pass.